### PR TITLE
chore: 将前端代码中的硬编码API地址替换为空

### DIFF
--- a/frontend/src/context/VpnSpeedContext.tsx
+++ b/frontend/src/context/VpnSpeedContext.tsx
@@ -21,7 +21,7 @@ interface VpnSpeedContextValue {
 
 const VpnSpeedContext = createContext<VpnSpeedContextValue | null>(null);
 
-const API_BASE_URL = 'http://10.88.202.59:3132';
+const API_BASE_URL = '';
 
 export function VpnSpeedProvider({ children }: { children: ReactNode }) {
   const [speed, setSpeed] = useState<VpnSpeedData>({

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -10,7 +10,7 @@ import { VpnSpeedMonitor } from '../components/monitor/VpnSpeedMonitor';
 import animations from './HomeAnimations.module.css';
 import { getCache, setCache } from '../utils/cache';
 
-const API_BASE_URL = 'http://10.88.202.59:3132';
+const API_BASE_URL = '';
 
 interface FetchOptions extends RequestInit {
   timeout?: number;

--- a/frontend/src/pages/Newest.tsx
+++ b/frontend/src/pages/Newest.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { PageTransition } from '../components/layout/PageTransition';
 import { RippleButton } from '../components/ui/RippleButton';
 
-const API_BASE_URL = 'http://10.88.202.59:3132';
+const API_BASE_URL = '';
 
 const VPN_IPS = [
   '10.88.194.142',


### PR DESCRIPTION
将多个页面和上下文组件里的固定后端API地址从http://10.88.202.59:3132改为空字符串