### PR TITLE
fix(server): 修复VPN速率查询的兼容性和稳定性问题

### DIFF
--- a/frontend/src/components/background/BackgroundOrbs.tsx
+++ b/frontend/src/components/background/BackgroundOrbs.tsx
@@ -16,8 +16,7 @@ export function BackgroundOrbs({ dimmed = false }: BackgroundOrbsProps) {
   const [orb1Pos, setOrb1Pos] = useState({ x: 0, y: 0 });
   const [orb2Pos, setOrb2Pos] = useState({ x: 0, y: 0 });
   const [gridOffset, setGridOffset] = useState({ x: 0, y: 0 });
-  const animationFrameRef = useRef<number>();
-  const lastMouseRef = useRef({ x: 0, y: 0 });
+  const animationFrameRef = useRef<number>(0);
 
   useEffect(() => {
     if (!isAnimated || isMobile) return;

--- a/server/server.js
+++ b/server/server.js
@@ -48,48 +48,65 @@ loadLastOnlineTimes();
 app.get('/api/vpn-speed', (req, res) => {
     console.log(`[${new Date().toISOString()}] 查询VPN速率`);
 
-    const psCommand = `
-        $received = Get-Counter -Counter "\\Network Interface(*)\\Bytes Received/sec" -ErrorAction SilentlyContinue
-        $sent = Get-Counter -Counter "\\Network Interface(*)\\Bytes Sent/sec" -ErrorAction SilentlyContinue
-        
-        $totalReceived = 0
-        if ($received) {
-            $totalReceived = ($received.CounterSamples | Measure-Object -Property CookedValue -Sum).Sum
+    const psScript = `
+try {
+    $nicStats = Get-WmiObject -Class Win32_PerfFormattedData_Tcpip_NetworkInterface -ErrorAction SilentlyContinue
+    if ($nicStats) {
+        $totalReceived = ($nicStats | Measure-Object -Property BytesReceivedPerSec -Sum).Sum
+        $totalSent = ($nicStats | Measure-Object -Property BytesSentPerSec -Sum).Sum
+    } else {
+        $nicStats = Get-CimInstance -ClassName Win32_PerfFormattedData_Tcpip_NetworkInterface -ErrorAction SilentlyContinue
+        if ($nicStats) {
+            $totalReceived = ($nicStats | Measure-Object -Property BytesReceivedPerSec -Sum).Sum
+            $totalSent = ($nicStats | Measure-Object -Property BytesSentPerSec -Sum).Sum
         }
-        
-        $totalSent = 0
-        if ($sent) {
-            $totalSent = ($sent.CounterSamples | Measure-Object -Property CookedValue -Sum).Sum
-        }
-        
-        Write-Output ("{0},{1}" -f [math]::Round($totalReceived), [math]::Round($totalSent))
-    `.trim();
+    }
+    
+    if ($totalReceived -eq $null) { $totalReceived = 0 }
+    if ($totalSent -eq $null) { $totalSent = 0 }
+    
+    Write-Output ("{0},{1}" -f [math]::Round($totalReceived), [math]::Round($totalSent))
+} catch {
+    Write-Output "0,0"
+}
+`;
 
-    exec(`powershell -Command "${psCommand}"`, (error, stdout, stderr) => {
-        if (error) {
-            console.error(`[ERROR] 获取网络速率失败: ${error.message}`);
+    const tempFilePath = path.join(__dirname, 'temp_speed_check.ps1');
+    
+    fs.writeFile(tempFilePath, psScript, (writeErr) => {
+        if (writeErr) {
+            console.error(`[ERROR] 写入临时文件失败: ${writeErr.message}`);
             return res.json({ uploadSpeed: 0, downloadSpeed: 0, timestamp: Date.now() });
         }
 
-        const output = stdout.trim();
-        console.log(`[DEBUG] PowerShell output: "${output}"`);
-        
-        const parts = output.split(',');
-        
-        if (parts.length >= 2) {
-            const bytesReceivedPerSec = parseInt(parts[0] || '0', 10);
-            const bytesSentPerSec = parseInt(parts[1] || '0', 10);
-            const now = Date.now();
+        exec(`powershell -ExecutionPolicy Bypass -Command "& '${tempFilePath}'"`, (error, stdout, stderr) => {
+            fs.unlink(tempFilePath, () => {});
 
-            res.json({
-                uploadSpeed: Math.max(0, bytesSentPerSec),
-                downloadSpeed: Math.max(0, bytesReceivedPerSec),
-                timestamp: now
-            });
-        } else {
-            console.error('[ERROR] 无法解析网络速率输出:', output);
-            res.json({ uploadSpeed: 0, downloadSpeed: 0, timestamp: Date.now() });
-        }
+            if (error) {
+                console.error(`[ERROR] 获取网络速率失败: ${error.message}`);
+                return res.json({ uploadSpeed: 0, downloadSpeed: 0, timestamp: Date.now() });
+            }
+
+            const output = stdout.trim();
+            console.log(`[DEBUG] PowerShell output: "${output}"`);
+            
+            const parts = output.split(',');
+            
+            if (parts.length >= 2) {
+                const downloadSpeed = parseInt(parts[0] || '0', 10);
+                const uploadSpeed = parseInt(parts[1] || '0', 10);
+                const now = Date.now();
+
+                res.json({
+                    uploadSpeed: Math.max(0, uploadSpeed),
+                    downloadSpeed: Math.max(0, downloadSpeed),
+                    timestamp: now
+                });
+            } else {
+                console.error('[ERROR] 无法解析网络速率输出:', output);
+                res.json({ uploadSpeed: 0, downloadSpeed: 0, timestamp: Date.now() });
+            }
+        });
     });
 });
 


### PR DESCRIPTION
1. 重构Windows网络速率获取脚本，改用WMI/CIM接口替代Get-Counter，适配更多系统环境
2. 添加异常捕获机制，脚本执行出错时返回默认值避免服务崩溃
3. 将脚本写入临时文件执行，解决长命令转义问题，同时执行后清理临时文件
4. 调整变量命名，提升代码可读性