### PR TITLE
refactor(frontend): 重构鼠标位置钩子与动画组件逻辑

### DIFF
--- a/frontend/src/components/animations/CanvasParticleSystem.tsx
+++ b/frontend/src/components/animations/CanvasParticleSystem.tsx
@@ -1,5 +1,5 @@
 import { useRef, useEffect, useCallback, memo } from 'react';
-import { useMousePosition } from '../../hooks/useMousePosition';
+import { useMousePositionRef } from '../../hooks/useMousePosition';
 import { useAnimationFrame } from '../../hooks/useAnimationFrame';
 
 interface Particle {
@@ -84,7 +84,7 @@ function CanvasParticleSystemComponent({
   enabled = true,
 }: CanvasParticleSystemProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const mouse = useMousePosition();
+  const mouseRef = useMousePositionRef();
   const particlePoolRef = useRef<ParticlePool | null>(null);
   const lastSpawnRef = useRef(0);
   const offscreenCanvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -146,6 +146,7 @@ function CanvasParticleSystemComponent({
     const pool = particlePoolRef.current;
     if (!pool) return;
 
+    const mouse = mouseRef.current;
     const now = Date.now();
     if (now - lastSpawnRef.current > 50 && pool.getActiveCount() < maxParticles) {
       pool.acquire(mouse.x, mouse.y);

--- a/frontend/src/components/animations/MouseFollower.tsx
+++ b/frontend/src/components/animations/MouseFollower.tsx
@@ -1,5 +1,5 @@
 import { useRef, memo, useEffect, useCallback } from 'react';
-import { useMousePosition } from '../../hooks/useMousePosition';
+import { useMousePositionRef } from '../../hooks/useMousePosition';
 import { useAnimationFrame } from '../../hooks/useAnimationFrame';
 import { useHover } from '../../context/HoverContext';
 import { usePerformance } from '../../context/PerformanceContext';
@@ -13,6 +13,7 @@ interface Ripple {
   x: number;
   y: number;
   createdAt: number;
+  type: 'click' | 'press';
 }
 
 interface Point {
@@ -23,7 +24,7 @@ interface Point {
 export const MouseFollower = memo(function MouseFollower({ enabled: externalEnabled = true }: MouseFollowerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const rippleContainerRef = useRef<HTMLDivElement>(null);
-  const mouse = useMousePosition();
+  const mouseRef = useMousePositionRef();
   const { isHovering } = useHover();
   const { settings } = usePerformance();
 
@@ -31,7 +32,7 @@ export const MouseFollower = memo(function MouseFollower({ enabled: externalEnab
   const velocity = useRef<Point>({ x: 0, y: 0 });
   const ripples = useRef<Ripple[]>([]);
   const isPressed = useRef(false);
-  const pressTime = useRef(0);
+  const pressTimeRef = useRef(0);
 
   const isEnabled = externalEnabled && settings.mouseFollower;
 
@@ -105,37 +106,31 @@ export const MouseFollower = memo(function MouseFollower({ enabled: externalEnab
   }, []);
 
   useEffect(() => {
-    let lastPressed = false;
-    
     const handleMouseDown = () => {
       isPressed.current = true;
-      pressTime.current = performance.now();
+      pressTimeRef.current = performance.now();
     };
     const handleMouseUp = () => {
       isPressed.current = false;
     };
+    const handleClick = (e: MouseEvent) => {
+      ripples.current.push({
+        id: Date.now() + Math.random(),
+        x: e.clientX,
+        y: e.clientY,
+        createdAt: performance.now(),
+        type: 'click',
+      });
+    };
 
     window.addEventListener('mousedown', handleMouseDown);
     window.addEventListener('mouseup', handleMouseUp);
-
-    const tick = () => {
-      if (isPressed.current && !lastPressed) {
-        ripples.current.push({
-          id: Date.now() + Math.random(),
-          x: currentPos.current.x,
-          y: currentPos.current.y,
-          createdAt: performance.now(),
-        });
-      }
-      lastPressed = isPressed.current;
-    };
-
-    const intervalId = setInterval(tick, 16);
+    window.addEventListener('click', handleClick);
     
     return () => {
-      clearInterval(intervalId);
       window.removeEventListener('mousedown', handleMouseDown);
       window.removeEventListener('mouseup', handleMouseUp);
+      window.removeEventListener('click', handleClick);
     };
   }, []);
 
@@ -146,7 +141,7 @@ export const MouseFollower = memo(function MouseFollower({ enabled: externalEnab
 
     if (!containerRef.current) return;
 
-    const targetPos = mouse;
+    const targetPos = mouseRef.current;
     
     const lerpFactor = isHovering ? 0.28 : 0.18;
     const dx = targetPos.x - currentPos.current.x;
@@ -166,7 +161,7 @@ export const MouseFollower = memo(function MouseFollower({ enabled: externalEnab
     
     let pressScale = 1;
     if (isPressed.current) {
-      const pressDuration = performance.now() - pressTime.current;
+      const pressDuration = performance.now() - pressTimeRef.current;
       if (pressDuration < 100) {
         pressScale = 1 - (pressDuration / 100) * 0.25;
       } else {

--- a/frontend/src/components/animations/ParticleNetwork.tsx
+++ b/frontend/src/components/animations/ParticleNetwork.tsx
@@ -1,12 +1,11 @@
 import { useRef, useEffect, useCallback, useState, memo } from 'react';
-import { useMousePosition } from '../../hooks/useMousePosition';
+import { useMousePositionRef } from '../../hooks/useMousePosition';
 import { useAnimationFrame } from '../../hooks/useAnimationFrame';
 import { usePerformance } from '../../context/PerformanceContext';
 
 interface ParticleNetworkProps {
   particleCount?: number;
   connectionDistance?: number;
-  particleColor?: string;
   enabled?: boolean;
   dimmed?: boolean;
 }
@@ -87,12 +86,11 @@ class SpatialGrid {
 function ParticleNetworkComponent({
   particleCount = 150,
   connectionDistance = 200,
-  particleColor = '#00ff9d',
   enabled = true,
   dimmed = false,
 }: ParticleNetworkProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const mouse = useMousePosition();
+  const mouseRef = useMousePositionRef();
   const particlesRef = useRef<Particle[]>([]);
   const initializedRef = useRef(false);
   const [effectiveParticleCount, setEffectiveParticleCount] = useState(particleCount);
@@ -222,6 +220,7 @@ function ParticleNetworkComponent({
       ctx.fill();
     });
 
+    const mouse = mouseRef.current;
     const nearestParticles: { particle: Particle; distance: number }[] = [];
     for (const p of particles) {
       const dx = mouse.x - p.x;
@@ -244,7 +243,7 @@ function ParticleNetworkComponent({
       ctx.lineTo(mouse.x, mouse.y);
       ctx.stroke();
     });
-  }, [mouse, connectionDistance, particleColor]);
+  }, [connectionDistance]);
 
   useEffect(() => {
     if (initializedRef.current && canvasRef.current) {

--- a/frontend/src/hooks/useAnimationFrame.ts
+++ b/frontend/src/hooks/useAnimationFrame.ts
@@ -1,22 +1,73 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useCallback } from 'react';
 
-export function useAnimationFrame(callback: (deltaTime: number) => void) {
+interface AnimationFrameOptions {
+  maxFps?: number;
+  enabled?: boolean;
+}
+
+export function useAnimationFrame(
+  callback: (deltaTime: number, fps: number) => void,
+  options: AnimationFrameOptions = {}
+) {
+  const { maxFps = 60, enabled = true } = options;
+  
   const requestRef = useRef<number | undefined>(undefined);
   const previousTimeRef = useRef<number | undefined>(undefined);
   const callbackRef = useRef(callback);
   const animateRef = useRef<(time: number) => void>((_) => {});
-  
+  const frameCountRef = useRef(0);
+  const lastFpsUpdateRef = useRef(0);
+  const currentFpsRef = useRef(60);
+  const enabledRef = useRef(enabled);
+  const minFrameTime = 1000 / maxFps;
+
   useEffect(() => {
     callbackRef.current = callback;
   }, [callback]);
 
   useEffect(() => {
+    enabledRef.current = enabled;
+  }, [enabled]);
+
+  const start = useCallback(() => {
+    if (requestRef.current) return;
+    previousTimeRef.current = performance.now();
+    requestRef.current = requestAnimationFrame(animateRef.current);
+  }, []);
+
+  const stop = useCallback(() => {
+    if (requestRef.current) {
+      cancelAnimationFrame(requestRef.current);
+      requestRef.current = undefined;
+    }
+  }, []);
+
+  useEffect(() => {
     animateRef.current = (time: number) => {
+      if (!enabledRef.current) {
+        requestRef.current = requestAnimationFrame(animateRef.current);
+        return;
+      }
+
       if (previousTimeRef.current !== undefined) {
         const deltaTime = time - previousTimeRef.current;
-        callbackRef.current(deltaTime);
+        
+        if (deltaTime >= minFrameTime) {
+          frameCountRef.current++;
+          
+          if (time - lastFpsUpdateRef.current >= 1000) {
+            currentFpsRef.current = Math.round((frameCountRef.current * 1000) / (time - lastFpsUpdateRef.current));
+            frameCountRef.current = 0;
+            lastFpsUpdateRef.current = time;
+          }
+          
+          callbackRef.current(deltaTime, currentFpsRef.current);
+          previousTimeRef.current = time;
+        }
+      } else {
+        previousTimeRef.current = time;
       }
-      previousTimeRef.current = time;
+      
       requestRef.current = requestAnimationFrame(animateRef.current);
     };
 
@@ -27,5 +78,7 @@ export function useAnimationFrame(callback: (deltaTime: number) => void) {
         cancelAnimationFrame(requestRef.current);
       }
     };
-  }, []);
+  }, [minFrameTime]);
+
+  return { start, stop };
 }

--- a/frontend/src/hooks/useMousePosition.ts
+++ b/frontend/src/hooks/useMousePosition.ts
@@ -1,19 +1,45 @@
-import { useState, useEffect } from 'react';
+import { useRef, useEffect, useCallback } from 'react';
 
-export function useMousePosition() {
-  const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
+export interface MousePosition {
+  x: number;
+  y: number;
+}
+
+export function useMousePosition(): MousePosition {
+  const positionRef = useRef<MousePosition>({ x: 0, y: 0 });
+  const position = useRef<MousePosition>({ x: 0, y: 0 });
+
+  const updatePosition = useCallback((ev: MouseEvent) => {
+    positionRef.current.x = ev.clientX;
+    positionRef.current.y = ev.clientY;
+    position.current.x = ev.clientX;
+    position.current.y = ev.clientY;
+  }, []);
 
   useEffect(() => {
-    const updateMousePosition = (ev: MouseEvent) => {
-      setMousePosition({ x: ev.clientX, y: ev.clientY });
+    window.addEventListener('mousemove', updatePosition);
+    return () => {
+      window.removeEventListener('mousemove', updatePosition);
+    };
+  }, [updatePosition]);
+
+  return positionRef.current;
+}
+
+export function useMousePositionRef(): { current: MousePosition } {
+  const positionRef = useRef<MousePosition>({ x: 0, y: 0 });
+
+  useEffect(() => {
+    const updatePosition = (ev: MouseEvent) => {
+      positionRef.current.x = ev.clientX;
+      positionRef.current.y = ev.clientY;
     };
 
-    window.addEventListener('mousemove', updateMousePosition);
-
+    window.addEventListener('mousemove', updatePosition);
     return () => {
-      window.removeEventListener('mousemove', updateMousePosition);
+      window.removeEventListener('mousemove', updatePosition);
     };
   }, []);
 
-  return mousePosition;
+  return positionRef;
 }


### PR DESCRIPTION
1. 将useMousePosition拆分为返回值和ref两种形式，优化动画组件性能
2. 给useAnimationFrame新增FPS限制、开关控制和FPS回调参数
3. 移除ParticleNetwork的多余props和依赖项
4. 优化MouseFollower的涟漪生成逻辑和变量命名